### PR TITLE
Add warning for missing rounds from the database

### DIFF
--- a/cmd/db-migration/db-migration.go
+++ b/cmd/db-migration/db-migration.go
@@ -12,6 +12,7 @@ import (
 )
 
 var (
+	verbosePath     = flag.Bool("verbose", false, "Should the logs include DEBUG and INFO level logs or not.")
 	sourcePath      = flag.String("source", "", "The source database to be migrated to the new format.")
 	beaconName      = flag.String("beacon", "", "The name of the beacon to be migrated.")
 	migrationTarget = flag.String("target", "", "The type of database to migrate to. Supported values: boltdb, postgres.\n"+
@@ -34,13 +35,17 @@ var (
 
 func main() {
 	flag.Parse()
-	logger := log.NewLogger(nil, log.LogDebug)
+	logLevel := log.LogWarn
+	if *verbosePath {
+		logLevel = log.LogDebug
+	}
+	logger := log.NewLogger(nil, logLevel)
 
 	err := run(logger)
 	if err != nil && !errors.Is(err, migration.ErrMigrationNotNeeded) {
 		logger.Panicw("while migrating the database", "err", err)
 	}
-	logger.Infow("finished migration process")
+	logger.Debugw("finished migration process")
 }
 
 func run(logger log.Logger) error {

--- a/tests/db-migration/test.sh
+++ b/tests/db-migration/test.sh
@@ -110,7 +110,7 @@ err "[+] building drand db-migration tool ..."
 go build -o db-migration-test ./cmd/db-migration/
 
 err "[+] checking database before migration..."
-$tmp/drand-test-v148 sync --sync-nodes 127.0.0.1:$((p[0]+1)) --control "${p[0]}" --up-to 20
+$tmp/drand-test-v148 sync --sync-nodes 127.0.0.1:$((p[0]+1)) --control "${p[0]}" --up-to 20 --id default
 
 err "[+] Stopping instances ..."
 for pid in "${bgPIDs[@]}"; do
@@ -149,7 +149,7 @@ done
 sleep 1
 
 err "[+] checking database after migration..."
-$tmp/drand-master sync --sync-nodes 127.0.0.1:$((p[0]+1)) --control "${p[0]}" --up-to 20
+$tmp/drand-master sync --sync-nodes 127.0.0.1:$((p[0]+1)) --control "${p[0]}" --up-to 20 --id default
 
 sleep 1
 


### PR DESCRIPTION
Example output, timestamps omitted for brevity:
```
WARN    migration/migration.go:431      missing round(s) detected       {"previousRound": 1886265, "currentRound": 1887553}
WARN    migration/migration.go:405      It seems that there are gaps in the existing rounds.    {"totalMissingRounds": 1288}
WARN    migration/migration.go:406      To fix these, launch the drand daemon with this new migrated database, then run drand sync to add the missing ones.
WARN    migration/migration.go:407      You do not need to run the database migration tool again after the sync operation.
```